### PR TITLE
fix: iOS sizing and color scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .npm
 *.tgz
 dist
+ninjakit.dev
 node_modules

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Ninja Kit
 
 [Apache 2.0 License](LICENSE.md) | [Security Policy](SECURITY.md) | [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## WSL2 LAN access:
+
+```powershell
+netsh advfirewall firewall add rule name="Allowing LAN connections" dir=in action=allow protocol=TCP localport=3000
+netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=3000 connectaddress=<ip addr> connectport=3000
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"@types/react-dom": "17.0.11",
 				"@typescript-eslint/eslint-plugin": "5.5.0",
 				"@typescript-eslint/parser": "5.5.0",
+				"@vitejs/plugin-legacy": "1.6.3",
 				"@vitejs/plugin-react": "1.1.0",
 				"eslint": "8.3.0",
 				"eslint-config-prettier": "8.3.0",
@@ -824,6 +825,15 @@
 				"core-js-pure": "^3.19.0",
 				"regenerator-runtime": "^0.13.4"
 			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/standalone": {
+			"version": "7.16.4",
+			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.16.4.tgz",
+			"integrity": "sha512-FDRLwjeQfPm5jaHNuB+vwNyGCp24Ah3kEsbLzKmh0eSru+QCr4DmjgbRPoz71AwXLVtXU+l/i7MlVlIj5XO7Gw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -2406,6 +2416,25 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@vitejs/plugin-legacy": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.6.3.tgz",
+			"integrity": "sha512-YivdG6gT91/wjFL6woTwVRgK9KHrju8GwXwgv5FdfAVo0GK0FK4V+YEobmDKRcOMKXQ1U5awY5HqbPIsoJalKQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/standalone": "^7.16.4",
+				"core-js": "^3.19.1",
+				"magic-string": "^0.25.7",
+				"regenerator-runtime": "^0.13.9",
+				"systemjs": "^6.11.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"vite": "^2.0.0"
+			}
+		},
 		"node_modules/@vitejs/plugin-react": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.1.0.tgz",
@@ -3222,6 +3251,17 @@
 			"dev": true,
 			"dependencies": {
 				"is-what": "^3.12.0"
+			}
+		},
+		"node_modules/core-js": {
+			"version": "3.19.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.2.tgz",
+			"integrity": "sha512-ciYCResnLIATSsXuXnIOH4CbdfgV+H1Ltg16hJFN7/v6OxqnFr/IFGeLacaZ+fHLAm0TBbXwNK9/DNBzBUrO/g==",
+			"dev": true,
+			"hasInstallScript": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
 			}
 		},
 		"node_modules/core-js-pure": {
@@ -6688,6 +6728,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.4"
 			}
 		},
 		"node_modules/make-error": {
@@ -11885,6 +11934,12 @@
 			"integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
 			"dev": true
 		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
+		},
 		"node_modules/spawn-error-forwarder": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -12229,6 +12284,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/systemjs": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.11.0.tgz",
+			"integrity": "sha512-7YPIY44j+BoY+E6cGBSw0oCU8SNTTIHKZgftcBdwWkDzs/M86Fdlr21FrzAyph7Zo8r3CFGscyFe4rrBtixrBg==",
+			"dev": true
 		},
 		"node_modules/temp-dir": {
 			"version": "2.0.0",
@@ -13413,6 +13474,12 @@
 				"core-js-pure": "^3.19.0",
 				"regenerator-runtime": "^0.13.4"
 			}
+		},
+		"@babel/standalone": {
+			"version": "7.16.4",
+			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.16.4.tgz",
+			"integrity": "sha512-FDRLwjeQfPm5jaHNuB+vwNyGCp24Ah3kEsbLzKmh0eSru+QCr4DmjgbRPoz71AwXLVtXU+l/i7MlVlIj5XO7Gw==",
+			"dev": true
 		},
 		"@babel/template": {
 			"version": "7.16.0",
@@ -14623,6 +14690,19 @@
 				"eslint-visitor-keys": "^3.0.0"
 			}
 		},
+		"@vitejs/plugin-legacy": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.6.3.tgz",
+			"integrity": "sha512-YivdG6gT91/wjFL6woTwVRgK9KHrju8GwXwgv5FdfAVo0GK0FK4V+YEobmDKRcOMKXQ1U5awY5HqbPIsoJalKQ==",
+			"dev": true,
+			"requires": {
+				"@babel/standalone": "^7.16.4",
+				"core-js": "^3.19.1",
+				"magic-string": "^0.25.7",
+				"regenerator-runtime": "^0.13.9",
+				"systemjs": "^6.11.0"
+			}
+		},
 		"@vitejs/plugin-react": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.1.0.tgz",
@@ -15236,6 +15316,12 @@
 			"requires": {
 				"is-what": "^3.12.0"
 			}
+		},
+		"core-js": {
+			"version": "3.19.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.2.tgz",
+			"integrity": "sha512-ciYCResnLIATSsXuXnIOH4CbdfgV+H1Ltg16hJFN7/v6OxqnFr/IFGeLacaZ+fHLAm0TBbXwNK9/DNBzBUrO/g==",
+			"dev": true
 		},
 		"core-js-pure": {
 			"version": "3.19.1",
@@ -17804,6 +17890,15 @@
 			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
+			}
+		},
+		"magic-string": {
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.4"
 			}
 		},
 		"make-error": {
@@ -21599,6 +21694,12 @@
 			"integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
 			"dev": true
 		},
+		"sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
+		},
 		"spawn-error-forwarder": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -21882,6 +21983,12 @@
 					}
 				}
 			}
+		},
+		"systemjs": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.11.0.tgz",
+			"integrity": "sha512-7YPIY44j+BoY+E6cGBSw0oCU8SNTTIHKZgftcBdwWkDzs/M86Fdlr21FrzAyph7Zo8r3CFGscyFe4rrBtixrBg==",
+			"dev": true
 		},
 		"temp-dir": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"@types/react-dom": "17.0.11",
 		"@typescript-eslint/eslint-plugin": "5.5.0",
 		"@typescript-eslint/parser": "5.5.0",
+		"@vitejs/plugin-legacy": "1.6.3",
 		"@vitejs/plugin-react": "1.1.0",
 		"eslint": "8.3.0",
 		"eslint-config-prettier": "8.3.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
+import "./style.css";
+
 import {
 	Button,
 	Card,

--- a/src/lib/color-scheme.ts
+++ b/src/lib/color-scheme.ts
@@ -1,5 +1,8 @@
-const localColorScheme = localStorage.getItem("prefersColorScheme");
-const systemColorScheme = matchMedia("(prefers-color-scheme: dark)")
+const localColorScheme = localStorage.getItem("prefersColorScheme") as
+	| "light"
+	| "dark"
+	| null;
+const systemColorScheme = matchMedia("(prefers-color-scheme: dark)").matches
 	? "dark"
 	: "light";
 const colorScheme = localColorScheme || systemColorScheme;

--- a/src/lib/components/button/button.module.css
+++ b/src/lib/components/button/button.module.css
@@ -16,15 +16,15 @@
 .filled .state,
 .text,
 .text .state {
-	border-radius: 20rem;
-	height: 40rem;
+	border-radius: 2rem;
+	height: 4rem;
 }
 
 .floating,
 .floating .state {
-	border-radius: 16rem;
-	height: 56rem;
-	min-width: 56rem;
+	border-radius: 1.6rem;
+	height: 5.6rem;
+	min-width: 5.6rem;
 }
 
 .filled {
@@ -36,7 +36,7 @@
 	background-color: var(--nk-color-primary-container);
 	box-shadow: var(--nk-shadow);
 	color: var(--nk-color-on-primary-container);
-	margin: 8rem;
+	margin: 0.8rem;
 }
 
 .text .state {
@@ -53,35 +53,35 @@
 
 .filled.children:not(.icon) .state,
 .text.children:not(.icon) .state {
-	padding-left: 24rem;
-	padding-right: 24rem;
+	padding-left: 2.4rem;
+	padding-right: 2.4rem;
 }
 
 .floating.children:not(.icon) .state {
-	padding-left: 16rem;
-	padding-right: 16rem;
+	padding-left: 1.6rem;
+	padding-right: 1.6rem;
 }
 
 .filled.icon:not(.children) .state,
 .text.icon:not(.children) .state {
-	width: 40rem;
+	width: 4rem;
 }
 
 .filled.children.icon .state,
 .floating.children.icon .state,
 .text.children.icon .state {
-	gap: 8rem;
+	gap: 0.8rem;
 }
 
 .filled.children.icon .state,
 .text.children.icon .state {
-	padding-left: 16rem;
-	padding-right: 24rem;
+	padding-left: 1.6rem;
+	padding-right: 2.4rem;
 }
 
 .floating.children.icon .state {
-	padding-left: 12rem;
-	padding-right: 16rem;
+	padding-left: 1.2rem;
+	padding-right: 1.6rem;
 }
 
 .state {
@@ -129,19 +129,19 @@
 
 .filled svg,
 .text svg {
-	height: 18rem;
-	width: 18rem;
+	height: 1.8rem;
+	width: 1.8rem;
 }
 
 .floating svg {
-	height: 24rem;
-	width: 24rem;
+	height: 2.4rem;
+	width: 2.4rem;
 }
 
 @media screen and (min-width: 600px) {
 	.floating,
 	.floating .state {
-		border-radius: 12rem;
-		height: 40rem;
+		border-radius: 1.2rem;
+		height: 4rem;
 	}
 }

--- a/src/lib/components/card/card.module.css
+++ b/src/lib/components/card/card.module.css
@@ -1,13 +1,13 @@
 .elevated,
 .filled,
 .outlined {
-	border-radius: 12rem;
+	border-radius: 1.2rem;
 	box-shadow: var(--nk-shadow);
 	composes: nk from global;
 	display: flex;
 	flex-direction: column;
-	gap: 8rem;
-	padding: 12rem 16rem;
+	gap: 0.8rem;
+	padding: 1.2rem 1.6rem;
 }
 
 .elevated h1,
@@ -24,7 +24,7 @@
 .outlined > section {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8rem;
+	gap: 0.8rem;
 }
 
 .elevated,
@@ -37,5 +37,5 @@
 }
 
 .outlined {
-	border: 1rem solid var(--nk-color-outline);
+	border: 0.1rem solid var(--nk-color-outline);
 }

--- a/src/lib/components/grid/grid.module.css
+++ b/src/lib/components/grid/grid.module.css
@@ -26,16 +26,16 @@
 
 .article::-webkit-scrollbar,
 .nav::-webkit-scrollbar {
-	height: 8rem;
-	width: 8rem;
+	height: 0.8rem;
+	width: 0.8rem;
 }
 
 .article::-webkit-scrollbar-thumb,
 .nav::-webkit-scrollbar-thumb {
-	border-radius: 4rem;
+	border-radius: 0.4rem;
 	border-left-color: inherit;
 	border-left-style: solid;
-	border-left-width: 8rem;
+	border-left-width: 0.8rem;
 	position: absolute;
 	right: 0;
 }
@@ -43,12 +43,12 @@
 .article {
 	background-color: var(--nk-color-surface);
 	display: grid;
-	gap: 8rem;
+	gap: 0.8rem;
 	grid-area: article;
 	grid-template-areas: "main" "aside";
 	grid-template-columns: 1fr;
 	grid-template-rows: auto auto;
-	padding: 8rem;
+	padding: 0.8rem;
 }
 
 .article > aside {
@@ -60,9 +60,9 @@
 }
 
 .button {
-	bottom: 96rem;
+	bottom: 9.6rem;
 	position: fixed;
-	right: 16rem;
+	right: 1.6rem;
 }
 
 .fill {
@@ -72,9 +72,9 @@
 .header {
 	align-items: center;
 	display: flex;
-	gap: 8rem;
+	gap: 0.8rem;
 	grid-area: header;
-	padding: 16rem;
+	padding: 1.6rem;
 }
 
 .grid {
@@ -84,7 +84,6 @@
 	grid-template-columns: 1fr;
 	grid-template-rows: auto 1fr auto;
 	left: 0;
-	min-width: 320rem;
 	position: absolute;
 	right: 0;
 	top: 0;
@@ -92,24 +91,24 @@
 
 .nav {
 	display: flex;
-	gap: 8rem;
+	gap: 0.8rem;
 	grid-area: nav;
 	justify-content: center;
 }
 
 .navIndicator {
 	align-items: center;
-	border-radius: 16rem;
+	border-radius: 1.6rem;
 	display: flex;
-	height: 32rem;
+	height: 3.2rem;
 	justify-content: center;
-	width: 64rem;
+	width: 6.4rem;
 }
 
 .navIndicator svg {
 	box-sizing: border-box;
 	color: var(--nk-color-on-surface-variant);
-	font-size: 24rem;
+	font-size: 2.4rem;
 }
 
 .navLabel {
@@ -122,11 +121,11 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	gap: 4rem;
-	padding-bottom: 16rem;
-	padding-left: 16rem;
-	padding-right: 16rem;
-	padding-top: 12rem;
+	gap: 0.4rem;
+	padding-bottom: 1.6rem;
+	padding-left: 1.6rem;
+	padding-right: 1.6rem;
+	padding-top: 1.2rem;
 	text-decoration: unset;
 	transition-property: background-color;
 	transition-duration: 200ms;
@@ -169,7 +168,7 @@ span.navLink svg {
 
 	.article > aside,
 	.article > main {
-		padding: 8rem;
+		padding: 0.8rem;
 		border-left-color: transparent;
 		overflow-y: auto;
 		scrollbar-gutter: auto;
@@ -178,7 +177,7 @@ span.navLink svg {
 	}
 
 	.article > aside {
-		width: 256rem;
+		width: 25.6rem;
 	}
 
 	.article > aside:hover,
@@ -188,16 +187,16 @@ span.navLink svg {
 
 	.article > aside::-webkit-scrollbar,
 	.article > main::-webkit-scrollbar {
-		height: 8rem;
-		width: 8rem;
+		height: 0.8rem;
+		width: 0.8rem;
 	}
 
 	.article > aside::-webkit-scrollbar-thumb,
 	.article > main::-webkit-scrollbar-thumb {
-		border-radius: 4rem;
+		border-radius: 0.4rem;
 		border-left-color: inherit;
 		border-left-style: solid;
-		border-left-width: 8rem;
+		border-left-width: 0.8rem;
 		position: absolute;
 		right: 0;
 	}

--- a/src/lib/components/typography/typography.module.css
+++ b/src/lib/components/typography/typography.module.css
@@ -40,85 +40,85 @@
 }
 
 .displayLarge {
-	font-size: 57rem;
-	line-height: 64rem;
+	font-size: 5.7rem;
+	line-height: 6.4rem;
 }
 
 .displayMedium {
-	font-size: 45rem;
-	line-height: 52rem;
+	font-size: 4.5rem;
+	line-height: 5.2rem;
 }
 
 .displaySmall {
-	font-size: 36rem;
-	line-height: 44rem;
+	font-size: 3.6rem;
+	line-height: 4.4rem;
 }
 
 .headlineLarge {
-	font-size: 32rem;
-	line-height: 40rem;
+	font-size: 3.2rem;
+	line-height: 4rem;
 }
 
 .headlineMedium {
-	font-size: 28rem;
-	line-height: 36rem;
+	font-size: 2.8rem;
+	line-height: 3.6rem;
 }
 
 .headlineSmall {
-	font-size: 24rem;
-	line-height: 32rem;
+	font-size: 2.4rem;
+	line-height: 3.2rem;
 }
 
 .titleLarge {
-	font-size: 22rem;
-	line-height: 28rem;
+	font-size: 2.2rem;
+	line-height: 2.8rem;
 }
 
 .titleMedium {
-	font-size: 16rem;
-	line-height: 24rem;
+	font-size: 1.6rem;
+	line-height: 2.4rem;
 }
 
 .titleMedium,
 .bodyLarge {
-	letter-spacing: 0.15rem;
+	letter-spacing: 0.015rem;
 }
 
 .titleSmall,
 .labelLarge {
-	font-size: 14rem;
-	line-height: 20rem;
-	letter-spacing: 0.1rem;
+	font-size: 1.4rem;
+	line-height: 2rem;
+	letter-spacing: 0.01rem;
 }
 
 .labelMedium,
 .labelSmall {
-	letter-spacing: 0.5rem;
+	letter-spacing: 0.05rem;
 }
 
 .labelMedium {
-	font-size: 12rem;
-	line-height: 16rem;
+	font-size: 1.2rem;
+	line-height: 1.6rem;
 }
 
 .labelSmall {
-	font-size: 11rem;
-	line-height: 6rem;
+	font-size: 1.1rem;
+	line-height: 0.6rem;
 }
 
 .bodyLarge {
-	font-size: 16rem;
-	line-height: 20rem;
+	font-size: 1.6rem;
+	line-height: 2rem;
 }
 
 .bodyMedium {
-	font-size: 14rem;
-	line-height: 20rem;
-	letter-spacing: 0.25rem;
+	font-size: 1.4rem;
+	line-height: 2rem;
+	letter-spacing: 0.025rem;
 }
 
 .bodySmall {
-	font-size: 12rem;
-	line-height: 16rem;
-	letter-spacing: 0.4rem;
+	font-size: 1.2rem;
+	line-height: 1.6rem;
+	letter-spacing: 0.04rem;
 }

--- a/src/lib/hooks/color-scheme.ts
+++ b/src/lib/hooks/color-scheme.ts
@@ -25,6 +25,7 @@ export function useColorScheme() {
 
 		if (colorScheme === "system") {
 			const systemColorScheme = matchMedia("(prefers-color-scheme: dark)")
+				.matches
 				? "dark"
 				: "light";
 

--- a/src/lib/style.css
+++ b/src/lib/style.css
@@ -146,17 +146,13 @@
 		80%
 	);
 	--nk-font-family: roboto, system-ui, sans-serif;
-	--nk-shadow: 0 2rem 8rem -6rem var(--nk-color-shadow);
+	--nk-shadow: 0 0.2rem 0.8rem -0.6rem var(--nk-color-shadow);
 	background-color: var(--nk-color-background);
 	color: var(--nk-color-on-background);
 	color-scheme: light dark;
 	font-family: var(--nk-font-family);
-	font-size: 6.25%; /* 1rem == 1px (resolution independent) */
+	font-size: 62.5%; /* 1rem == 10px (resolution independent) */
 	font-weight: 400;
-}
-
-body {
-	display: contents;
 }
 
 .nk {
@@ -168,6 +164,7 @@ body {
 	box-sizing: border-box;
 	color: unset;
 	font-family: var(--nk-font-family);
+	font-size: inherit;
 	line-height: 1em;
 	outline-color: unset;
 	outline-offset: unset;
@@ -179,9 +176,6 @@ body {
 	transition-property: color;
 	transition-duration: 300ms;
 	transition-timing-function: linear;
-}
-
-@media screen and (prefers-color-scheme: dark) {
 }
 
 :root.dark {

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,3 @@
+body {
+	font-size: 1.2rem;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import legacy from "@vitejs/plugin-legacy";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
 import { defineConfig, UserConfig } from "vite";
@@ -9,7 +10,6 @@ export default defineConfig(({ mode }) => {
 			emptyOutDir: true,
 			outDir: resolve(__dirname, "dist"),
 		},
-		plugins: [react()],
 		resolve: { alias: { ninjakit: resolve(__dirname, "src/lib") } },
 	};
 
@@ -33,9 +33,18 @@ export default defineConfig(({ mode }) => {
 					generateScopedName: "ninjakit-[folder]-[local]-[contentHash]",
 				},
 			},
+			plugins: [react()],
 			root: resolve(__dirname, "src/lib"),
 		};
 	}
 
-	return { ...config, root: resolve(__dirname, "src") };
+	return {
+		...config,
+		plugins: [
+			react(),
+			legacy({ targets: ["defaults", "iOS 12", "not IE 11"] }),
+		],
+		root: resolve(__dirname, "src"),
+		server: { host: "0.0.0.0" },
+	};
 });


### PR DESCRIPTION
- adjust all `font-size` for a `1rem == 10px` scale, since iOS webkit
  cannot handle fractional percentages less than `.5`
- update color scheme system media with matches boolean for a correct
  default in iOS webkit