### PR TITLE
fix: button display name

### DIFF
--- a/src/lib/components/button/anchor.tsx
+++ b/src/lib/components/button/anchor.tsx
@@ -1,30 +1,16 @@
-import {
-	AnchorHTMLAttributes,
-	Children,
-	forwardRef,
-	PropsWithChildren,
-} from "react";
+import { AnchorHTMLAttributes, forwardRef } from "react";
 import { CgExternal } from "react-icons/cg";
 
-import typography from "../typography/typography.module.css";
-import type { ButtonProps } from "./";
-import styles from "./button.module.css";
+import { ButtonProps, useClassName } from ".";
 
 export const ButtonAnchor = forwardRef<
 	HTMLAnchorElement,
-	AnchorHTMLAttributes<HTMLAnchorElement> & PropsWithChildren<ButtonProps>
->(function ButtonLink(
-	{ appearance = "filled", children, className: override, target, ...props },
+	AnchorHTMLAttributes<HTMLAnchorElement> & ButtonProps
+>(function (
+	{ appearance, children, className: override, target, ...props },
 	ref
 ) {
-	const className = [
-		styles.button,
-		styles[appearance],
-		typography.labelLarge,
-		children && styles.children,
-		Children.count(children) > 1 && styles.icon,
-		override,
-	].join(" ");
+	const className = useClassName({ appearance, children, override });
 
 	return (
 		<a className={className} ref={ref} target={target} {...props}>
@@ -33,3 +19,5 @@ export const ButtonAnchor = forwardRef<
 		</a>
 	);
 });
+
+ButtonAnchor.displayName = "ButtonAnchor";

--- a/src/lib/components/button/button.tsx
+++ b/src/lib/components/button/button.tsx
@@ -1,0 +1,21 @@
+import { ButtonHTMLAttributes, forwardRef } from "react";
+
+import { ButtonProps, useClassName } from ".";
+
+export const Button = forwardRef<
+	HTMLButtonElement,
+	ButtonHTMLAttributes<HTMLButtonElement> & ButtonProps
+>(function (
+	{ appearance, children, className: override, type = "button", ...props },
+	ref
+) {
+	const className = useClassName({ appearance, children, override });
+
+	return (
+		<button className={className} ref={ref} type={type} {...props}>
+			{children}
+		</button>
+	);
+});
+
+Button.displayName = "Button";

--- a/src/lib/components/button/index.tsx
+++ b/src/lib/components/button/index.tsx
@@ -1,40 +1,33 @@
-import {
-	ButtonHTMLAttributes,
-	Children,
-	forwardRef,
-	PropsWithChildren,
-} from "react";
+import { Children, PropsWithChildren, ReactNode } from "react";
 
 import typography from "../typography/typography.module.css";
 import styles from "./button.module.css";
 
-export interface ButtonProps {
-	/** @see https://m3.material.io/components/all-buttons */
-	appearance?:
-		| "text"
-		| "outlined"
-		| "elevated"
-		| "tonal"
-		| "filled"
-		| "floating-small"
-		| "floating"
-		| "floating-large";
-}
+type Appearance =
+	| "text"
+	| "outlined"
+	| "elevated"
+	| "tonal"
+	| "filled"
+	| "floating-small"
+	| "floating"
+	| "floating-large";
 
-export const Button = forwardRef<
-	HTMLButtonElement,
-	ButtonHTMLAttributes<HTMLButtonElement> & PropsWithChildren<ButtonProps>
->(function Button(
-	{
-		appearance = "filled",
-		children,
-		className: override,
-		type = "button",
-		...props
-	},
-	ref
-) {
-	const className = [
+export type ButtonProps = PropsWithChildren<{
+	/** @see https://m3.material.io/components/all-buttons */
+	appearance?: Appearance;
+}>;
+
+export function useClassName({
+	appearance = "filled",
+	children,
+	override,
+}: {
+	appearance?: Appearance;
+	children: ReactNode;
+	override?: string;
+}): string | undefined {
+	return [
 		styles.button,
 		styles[appearance],
 		typography.labelLarge,
@@ -42,10 +35,7 @@ export const Button = forwardRef<
 		Children.count(children) > 1 && styles.icon,
 		override,
 	].join(" ");
+}
 
-	return (
-		<button className={className} ref={ref} type={type} {...props}>
-			{children}
-		</button>
-	);
-});
+export { ButtonAnchor } from "./anchor";
+export { Button } from "./button";


### PR DESCRIPTION
- add display name to Button/ButtonAnchor for React DevTools
- refactor Button/ButtonAnchor to separate files sharing common
  hook/type