### PR TITLE
fix: card label

### DIFF
--- a/src/docs/app.tsx
+++ b/src/docs/app.tsx
@@ -28,6 +28,7 @@ import { Logo } from "./components/logo";
 import { ReloadPrompt } from "./components/reload-prompt";
 import { Components } from "./pages/components";
 import { Dojo } from "./pages/dojo";
+import { Hooks } from "./pages/hooks";
 import { Settings } from "./pages/settings";
 
 function App() {
@@ -93,6 +94,7 @@ function App() {
 					<Routes>
 						<Route element={<Dojo />} path="/" />
 						<Route element={<Components />} path="components" />
+						<Route element={<Hooks />} path="hooks" />
 						<Route element={<Settings />} path="settings" />
 					</Routes>
 				</main>

--- a/src/docs/pages/hooks/index.tsx
+++ b/src/docs/pages/hooks/index.tsx
@@ -1,0 +1,5 @@
+import { FunctionComponent } from "react";
+
+import { Example } from "../../components/example";
+
+export const Hooks: FunctionComponent = () => <Example module="color-scheme" />;

--- a/src/lib/components/card/card.module.css
+++ b/src/lib/components/card/card.module.css
@@ -13,6 +13,13 @@
 	margin: 0;
 }
 
+.card label {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.4rem;
+}
+
 .card > section {
 	align-items: center;
 	display: flex;


### PR DESCRIPTION
- flex/center children of label element inside a Card component
- add hooks page with color-scheme example to website