### PR TITLE
fix: color scheme head script

### DIFF
--- a/.vscode/ninjakit.code-workspace
+++ b/.vscode/ninjakit.code-workspace
@@ -1,0 +1,22 @@
+{
+	"folders": [
+		{
+			"name": "ninjaKit",
+			"path": ".."
+		},
+		{
+			"name": "examples",
+			"path": "../../ninjakit-examples"
+		}
+	],
+	"remoteAuthority": "wsl+Ubuntu",
+	"settings": {
+		"files.exclude": {
+			"**/.git": true,
+			"build": true,
+			"coverage": true,
+			"dist": true,
+			"node_modules": true
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -94,9 +94,9 @@
 	"sideEffects": false,
 	"scripts": {
 		"build": "run-p build:**",
-		"build:color-scheme": "tsc src/lib/color-scheme.ts --outDir dist",
+		"build:head": "tsc --project src/lib/head",
 		"build:lib": "vite build --mode=lib",
-		"build:types": "tsc --emitDeclarationOnly --project tsconfig-lib.json",
+		"build:types": "tsc --emitDeclarationOnly --project tsconfig-types.json",
 		"check": "run-p check:**",
 		"check:config": "prettier --check .",
 		"check:scripts": "eslint --ext .ts,.tsx .",

--- a/src/lib/head/color-scheme.ts
+++ b/src/lib/head/color-scheme.ts
@@ -14,5 +14,3 @@ const metaElement = document.querySelector(
 ) as HTMLMetaElement;
 
 if (metaElement) metaElement.content = colorScheme;
-
-export {};

--- a/src/lib/head/tsconfig.json
+++ b/src/lib/head/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"isolatedModules": false,
+		"outDir": "../../../dist"
+	},
+	"exclude": [],
+	"extends": "../../../tsconfig.json",
+	"include": ["**/*.ts"]
+}

--- a/tsconfig-types.json
+++ b/tsconfig-types.json
@@ -4,7 +4,7 @@
 		"declarationMap": true,
 		"outDir": "./dist"
 	},
-	"exclude": ["**/*.test.*"],
+	"exclude": ["./src/lib/head", "**/*.test.*"],
 	"extends": "./tsconfig.json",
 	"include": ["./vite.d.ts", "./src/lib"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
 		"target": "ESNext",
 		"useDefineForClassFields": true
 	},
-	"exclude": ["./src/docs/worker.ts"],
+	"exclude": ["./src/lib/head", "./src/docs/worker.ts"],
 	"include": ["./vite.d.ts", "./src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,6 +85,15 @@ export default defineConfig(({ mode }) => {
 				registerType: "prompt",
 			}),
 		],
+		resolve: {
+			alias: {
+				"ninjakit/color-scheme": resolve(
+					__dirname,
+					"src/lib/head/color-scheme"
+				),
+				...config.resolve.alias,
+			},
+		},
 		root: resolve(__dirname, "src/docs"),
 		server: { host: "0.0.0.0" },
 	};


### PR DESCRIPTION
- change color-scheme script for head from a module to a standard script
- update configuration accordingly
- rename types config file for clarity of purpose
- add VSCode workspace to include examples repo