### PR TITLE
fix: text input refactor

### DIFF
--- a/src/docs/pages/examples/input-menu.tsx
+++ b/src/docs/pages/examples/input-menu.tsx
@@ -10,6 +10,7 @@ export const InputMenuExamples: FunctionComponent = () => {
 		<Card appearance="elevated" id="menu" title="InputMenu">
 			<section>
 				<InputMenu
+					id="input-menu-elevated"
 					label="Filled"
 					onChange={({ currentTarget: { value } }) =>
 						console.info("InputMenu", { value })
@@ -19,6 +20,7 @@ export const InputMenuExamples: FunctionComponent = () => {
 				</InputMenu>
 				<InputMenu
 					appearance="outlined"
+					id="input-menu-outlined"
 					label="Outlined"
 					onChange={({ currentTarget: { value } }) =>
 						console.info("InputMenu", { value })

--- a/src/docs/pages/examples/text-input.tsx
+++ b/src/docs/pages/examples/text-input.tsx
@@ -1,54 +1,83 @@
-import { Card, TextInput } from "ninjakit";
-import { FunctionComponent, useRef } from "react";
+import { Card, Checkbox, Radioset, TextInput } from "ninjakit";
+import { FunctionComponent, useRef, useState } from "react";
 import { MdCancel, MdFavorite } from "react-icons/md";
 
 export const TextInputExamples: FunctionComponent = () => {
-	const refFilled = useRef<HTMLInputElement>(null);
-	const refOutlined = useRef<HTMLInputElement>(null);
+	const ref = useRef<HTMLInputElement>(null);
+	const [{ appearance, error, helper, leadingIcon, trailingIcon }, setOptions] =
+		useState<{
+			appearance: "filled" | "outlined";
+			error: boolean;
+			helper: boolean;
+			leadingIcon: boolean;
+			trailingIcon: boolean;
+		}>({
+			appearance: "filled",
+			error: false,
+			helper: false,
+			leadingIcon: false,
+			trailingIcon: false,
+		});
 
 	return (
 		<Card appearance="elevated" id="text-input" title="TextInput">
 			<section>
-				<TextInput label="Filled" />
-				<TextInput
-					label="With Trailing Icon"
-					onClickTrailingIcon={() =>
-						refFilled.current && (refFilled.current.value = "")
-					}
-					ref={refFilled}
-					trailingIcon={<MdCancel />}
-				/>
-				<TextInput label="With Leading Icon" leadingIcon={<MdFavorite />} />
-				<TextInput
-					defaultValue="value"
-					error="Error message"
-					label="With Error"
-					leadingIcon={<MdFavorite />}
-				/>
-			</section>
-			<section>
-				<TextInput appearance="outlined" label="Outlined" />
-				<TextInput
-					appearance="outlined"
-					label="With Trailing Icon"
-					onClickTrailingIcon={() =>
-						refOutlined.current && (refOutlined.current.value = "")
-					}
-					ref={refOutlined}
-					trailingIcon={<MdCancel />}
-				/>
-				<TextInput
-					appearance="outlined"
-					label="With Leading Icon"
-					leadingIcon={<MdFavorite />}
-				/>
-				<TextInput
-					appearance="outlined"
-					defaultValue="value"
-					error="Error message"
-					label="With Error"
-					leadingIcon={<MdFavorite />}
-				/>
+				<section>
+					<TextInput
+						appearance={appearance}
+						error={error && "Error message"}
+						helper={helper ? "Helper message" : undefined}
+						id="text-input-example"
+						label="Label"
+						leadingIcon={leadingIcon && <MdFavorite />}
+						onClickTrailingIcon={() => {
+							if (ref.current) ref.current.value = "";
+						}}
+						ref={ref}
+						trailingIcon={trailingIcon && <MdCancel />}
+					/>
+				</section>
+				<aside>
+					<Radioset<"filled" | "outlined">
+						defaultValue="filled"
+						label="Appearance"
+						name="appearance"
+						onChange={(appearance) =>
+							setOptions((options) => ({ ...options, appearance }))
+						}
+						options={["filled", "outlined"]}
+					/>
+					<Checkbox
+						label="Leading icon"
+						onClick={() =>
+							setOptions((options) => ({
+								...options,
+								leadingIcon: !leadingIcon,
+							}))
+						}
+					/>
+					<Checkbox
+						label="Trailing icon"
+						onClick={() =>
+							setOptions((options) => ({
+								...options,
+								trailingIcon: !trailingIcon,
+							}))
+						}
+					/>
+					<Checkbox
+						label="Helper message"
+						onClick={() =>
+							setOptions((options) => ({ ...options, helper: !options.helper }))
+						}
+					/>
+					<Checkbox
+						label="Error message"
+						onClick={() =>
+							setOptions((options) => ({ ...options, error: !options.error }))
+						}
+					/>
+				</aside>
 			</section>
 		</Card>
 	);

--- a/src/lib/components/card/card.module.css
+++ b/src/lib/components/card/card.module.css
@@ -24,7 +24,15 @@
 	background-color: inherit;
 	display: flex;
 	flex-wrap: wrap;
-	gap: 0.4rem;
+	gap: 1.6rem;
+}
+
+.card > section > section {
+	flex: 2;
+}
+
+.card > section > aside {
+	flex: 1;
 }
 
 .elevated,

--- a/src/lib/components/input/index.ts
+++ b/src/lib/components/input/index.ts
@@ -8,8 +8,10 @@ type Appearance = "filled" | "outlined";
 export type InputProps = {
 	/** @see https://material.io/design/components/text-fields.html */
 	appearance?: Appearance;
-	error?: true | string;
-	label?: string;
+	error?: boolean | ReactNode;
+	helper?: ReactNode;
+	id: string; // id required by label htmlFor
+	label?: ReactNode;
 	leadingIcon?: ReactNode;
 	onClickTrailingIcon?: () => void;
 	trailingIcon?: ReactNode;
@@ -22,16 +24,16 @@ export function useClassName({
 	override,
 }: {
 	appearance?: Appearance;
-	error?: true | string;
+	error?: boolean | ReactNode;
 	leadingIcon?: ReactNode;
 	override?: string;
 }): string | undefined {
 	return [
 		typography.labelLarge,
-		styles.container,
+		styles.field,
 		styles[appearance],
-		leadingIcon && styles.leadingIcon,
-		error && styles.error,
+		leadingIcon ? styles.leadingIcon : undefined,
+		error ? styles.error : undefined,
 		override,
 	]
 		.join(" ")

--- a/src/lib/components/input/input.module.css
+++ b/src/lib/components/input/input.module.css
@@ -1,100 +1,37 @@
 .button,
-.container,
 .error,
+.field,
+.helper,
 .input,
-.label {
+.label,
+.row {
 	composes: nk from global;
 }
 
-.container {
+.field {
+	/* align-self: flex-start; */
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+
+.row {
 	align-items: center;
-	align-self: flex-start;
-	background-color: inherit;
-	caret-color: var(--md-color-primary);
-	color: var(--md-color-on-surface);
-	cursor: text;
 	display: flex;
 	height: 4.8rem;
+	justify-content: space-between;
 	position: relative;
-	transition: border-color border-width 300ms ease-in-out;
-}
-
-.container.filled,
-.container.filled::before {
-	border-radius: 0.4rem 0.4rem 0 0;
-}
-
-.container.filled {
-	box-shadow: 0 0.1rem 0 0 var(--md-color-outline);
-}
-
-.container.filled::before {
-	background-color: var(--md-color-primary);
-	content: "";
-	inset: 0;
-	opacity: 0.12;
-	position: absolute;
-}
-
-.container.filled:focus-within,
-.container.filled:hover {
-	box-shadow: 0 0.2rem 0 0 var(--md-color-outline);
-}
-
-.container.filled:focus-within {
-	box-shadow: 0 0.2rem 0 0 var(--md-color-primary);
-}
-
-.container.filled.error {
-	box-shadow: 0 0.2rem 0 0 var(--md-color-error);
-}
-
-.container.filled:focus-within::before {
-	opacity: 0.08;
-}
-
-.container.outlined {
-	border-radius: 0.4rem;
-	box-shadow: 0 0 0 0.1rem var(--md-color-outline);
-	margin: 0.8rem 0.1rem 0.1rem 0.1rem;
-}
-
-.container.outlined:focus-within,
-.container.outlined:hover {
-	box-shadow: 0 0 0 0.2rem var(--md-color-outline);
-}
-
-.container.outlined:focus-within {
-	box-shadow: 0 0 0 0.2rem var(--md-color-primary);
-}
-
-.container.outlined.error {
-	box-shadow: 0 0 0 0.2rem var(--md-color-error);
-}
-
-.container.error {
-	caret-color: var(--md-color-error);
-	margin-bottom: 2rem;
-}
-
-.container > .error {
-	bottom: -2rem;
-	color: var(--md-color-error);
-	font-size: 1.1rem;
-	left: 1.6rem;
-	position: absolute;
+	width: fit-content;
 }
 
 .input {
-	flex-grow: 1;
+	caret-color: var(--md-color-primary);
+	color: var(--md-color-on-surface);
 	font-size: 1.4rem;
-	height: 3.4rem;
+	height: 100%;
 	padding: 0 1.6rem;
 	position: relative;
-}
-
-.container.filled > .input {
-	align-self: flex-end;
+	transition: border-color border-width 300ms ease-in-out;
 }
 
 .input:placeholder-shown + .label {
@@ -107,6 +44,7 @@
 
 .label {
 	color: var(--md-color-outline);
+	cursor: text;
 	font-size: 1.4rem;
 	left: 1.6rem;
 	position: absolute;
@@ -115,11 +53,46 @@
 	user-select: none;
 }
 
-.container.leadingIcon > .input {
-	padding-left: 0.4rem;
+.button {
+	cursor: pointer;
+	position: absolute;
+	right: 1.6rem;
 }
 
-.container.leadingIcon > .label {
+.button:focus-visible > svg {
+	fill: var(--md-color-primary);
+}
+
+.errorMessage,
+.helperMessage {
+	font-size: 1.1rem;
+	margin-left: 1.6rem;
+}
+
+.errorMessage {
+	color: var(--md-color-error);
+}
+
+.helperMessage {
+	color: var(--md-color-on-surface);
+}
+
+.row svg {
+	fill: var(--md-color-outline);
+	height: 1.8rem;
+	width: 1.8rem;
+}
+
+.row > svg:first-child {
+	left: 1.6rem;
+	position: absolute;
+}
+
+.field.leadingIcon > .row > .input {
+	padding-left: 4.2rem;
+}
+
+.field.leadingIcon > .row > .label {
 	left: 4.2rem;
 }
 
@@ -137,42 +110,86 @@
 	transition-property: background-color, color;
 }
 
-.container.filled > .input:focus-within + .label,
-.container.filled > .input:-webkit-autofill + .label,
-.container.filled > .input:not(:placeholder-shown) + .label {
+.filled > .row::before,
+.filled > .row > .input {
+	border-radius: 0.4rem 0.4rem 0 0;
+}
+
+.filled > .row::before {
+	background-color: var(--md-color-primary);
+	content: "";
+	inset: 0;
+	opacity: 0.12;
+	position: absolute;
+}
+
+.filled > .row > .input {
+	box-shadow: 0 0.1rem 0 0 var(--md-color-outline);
+	padding-top: 1.6rem;
+}
+
+.filled > .row > .input:hover {
+	box-shadow: 0 0.2rem 0 0 var(--md-color-outline);
+}
+
+.filled > .row > .input:focus-within {
+	box-shadow: 0 0.2rem 0 0 var(--md-color-primary);
+}
+
+.filled.error > .row > .input {
+	box-shadow: 0 0.2rem 0 0 var(--md-color-error);
+}
+
+.row:focus-within::before {
+	opacity: 0.08;
+}
+
+.filled > .row > .input:focus-within + .label,
+.filled > .row > .input:-webkit-autofill + .label,
+.filled > .row > .input:not(:placeholder-shown) + .label {
 	transform: translate3d(0, -1rem, 0);
 }
 
-.container.outlined > .input:focus-within + .label,
-.container.outlined > .input:-webkit-autofill + .label,
-.container.outlined > .input:not(:placeholder-shown) + .label {
-	background-color: inherit;
+.outlined > .row,
+.outlined > .row > .label {
+	background-color: var(--md-color-surface);
+}
+
+.outlined > .row > .input {
+	border-radius: 0.4rem;
+	box-shadow: 0 0 0 0.1rem var(--md-color-outline);
+}
+
+.outlined > .row > .input:hover {
+	box-shadow: 0 0 0 0.2rem var(--md-color-outline);
+}
+
+.outlined > .row > .input:focus-within {
+	box-shadow: 0 0 0 0.2rem var(--md-color-primary);
+}
+
+.outlined.error > .row > .input {
+	box-shadow: 0 0 0 0.2rem var(--md-color-error);
+}
+
+.outlined > .row > .input:focus-within + .label,
+.outlined > .row > .input:-webkit-autofill + .label,
+.outlined > .row > .input:not(:placeholder-shown) + .label {
 	left: 0.8rem;
 	padding: 0 0.4rem;
 	transform: translate3d(0, -2.4rem, 0);
 }
 
-.container svg {
-	fill: var(--md-color-outline);
-	height: 1.8rem;
-	width: 1.8rem;
+.error > .row > .input {
+	caret-color: var(--md-color-error);
 }
 
-.container > svg {
-	margin-left: 1.6rem;
-}
-
-.container > .button {
-	cursor: pointer;
-	height: 4.8rem;
-	padding-right: 1.6rem;
-	position: relative;
-}
-
-.container > .button:focus-visible > svg {
-	fill: var(--md-color-primary);
-}
-
-.container.error > .label {
+.error > .row > .label {
 	color: var(--md-color-error);
+}
+
+@media screen and (min-width: 600px) {
+	.input {
+		font-size: 1.6rem; /* mobile Safari auto-zooms anything < 16px */
+	}
 }

--- a/src/lib/components/input/input.test.tsx
+++ b/src/lib/components/input/input.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from "@testing-library/react";
-import { Button } from "ninjakit";
+import { TextInput } from "ninjakit";
 
-describe("button", () => {
+describe("text input", () => {
 	test("default", () => {
-		render(<Button>test</Button>);
+		render(<TextInput id="test" label="test" />);
 
-		const $button = screen.getByRole("button", { name: "test" });
+		const $textInput = screen.getByRole("textbox", { name: "test" });
 
-		expect($button).toHaveClass("filled labelLarge children");
+		expect($textInput).toHaveClass("input");
 	});
 });

--- a/src/lib/components/input/text.tsx
+++ b/src/lib/components/input/text.tsx
@@ -5,16 +5,19 @@ import styles from "./input.module.css";
 
 export const TextInput = forwardRef<
 	HTMLInputElement,
-	JSX.IntrinsicElements["input"] & InputProps
+	Omit<JSX.IntrinsicElements["input"], "id"> & InputProps
 >(function (
 	{
 		appearance,
 		"aria-expanded": ariaExpanded,
+		"aria-invalid": ariaInvalid,
 		className: override,
 		error,
+		helper,
 		id,
 		label,
 		leadingIcon,
+		name,
 		onClickTrailingIcon: handleClick,
 		trailingIcon,
 		type = "text",
@@ -25,35 +28,43 @@ export const TextInput = forwardRef<
 	const className = useClassName({ appearance, error, leadingIcon, override });
 
 	return (
-		<label aria-expanded={ariaExpanded} className={className} htmlFor={id}>
-			<>{leadingIcon}</>
-			<input
-				{...props}
-				aria-label={label}
-				className={styles.input}
-				id={id}
-				placeholder={label}
-				ref={ref}
-				type={type}
-			/>
-			<div className={styles.label} role="presentation">
-				{label}
+		<div aria-expanded={ariaExpanded} className={className}>
+			<div className={styles.row}>
+				{leadingIcon}
+				<input
+					{...props}
+					aria-invalid={ariaInvalid || typeof error !== "undefined"}
+					className={styles.input}
+					id={id}
+					name={name}
+					placeholder={typeof label === "string" ? label : name || id}
+					ref={ref}
+					type={type}
+				/>
+				<label className={styles.label} htmlFor={id}>
+					{label}
+				</label>
+				{trailingIcon && (
+					<button
+						className={styles.button}
+						onClick={() => handleClick && handleClick()}
+						type="button"
+					>
+						{trailingIcon}
+					</button>
+				)}
 			</div>
-			{trailingIcon && (
-				<button
-					className={styles.button}
-					onClick={() => handleClick && handleClick()}
-					type="button"
-				>
-					{trailingIcon}
-				</button>
-			)}
-			{typeof error === "string" && (
-				<div className={styles.error} role="presentation">
+			{typeof error !== "undefined" && (
+				<div className={styles.errorMessage} role="tooltip">
 					{error}
 				</div>
 			)}
-		</label>
+			{typeof helper !== "undefined" && (
+				<div className={styles.helperMessage} role="tooltip">
+					{helper}
+				</div>
+			)}
+		</div>
 	);
 });
 

--- a/src/lib/components/menu/input.tsx
+++ b/src/lib/components/menu/input.tsx
@@ -27,21 +27,22 @@ export const InputMenu = forwardRef<
 		handleKeyDownMenu,
 		handleKeyDownMenuItem,
 	} = useMenu({ input: true, onChange, override });
-
 	const menuItems = mapMenuItems({
 		children,
 		handleClickMenuItem,
 		handleKeyDownMenuItem,
 	});
+	const menuId = `${id}-menu`;
 
 	return (
 		<div className={styles.container} role="presentation">
 			<TextInput
 				{...props}
-				aria-controls={id}
+				aria-controls={menuId}
 				aria-expanded={expanded}
 				aria-haspopup="menu"
 				className={styles.control}
+				id={id}
 				onClickTrailingIcon={handleClickControl}
 				onFocus={handleFocusControl}
 				onKeyDown={handleKeyDownControl}
@@ -52,7 +53,7 @@ export const InputMenu = forwardRef<
 			{expanded && (
 				<div
 					className={className}
-					id={id}
+					id={menuId}
 					onClick={handleClickMenu}
 					onKeyDown={handleKeyDownMenu}
 					role="menu"


### PR DESCRIPTION
- require id for label's htmlFor prop
- helper prop for message under input
- relax most props from strings to ReactNode for more flexibility
- improve internal layout/styling
- prevent auto-zooming in mobile Safari