### PR TITLE
fix: text input label

### DIFF
--- a/src/lib/components/input/input.module.css
+++ b/src/lib/components/input/input.module.css
@@ -126,10 +126,6 @@
 	padding-right: 4.2rem;
 }
 
-.field.trailingIcon > .row > .label {
-	right: 4.2rem;
-}
-
 .field.filled > .row::before,
 .field.filled > .row > .input {
 	border-radius: 0.4rem 0.4rem 0 0;


### PR DESCRIPTION
- remove right positioning of text input with trailing icon