### PR TITLE
fix: menu change events

### DIFF
--- a/src/docs/pages/examples/anchor-button/state.tsx
+++ b/src/docs/pages/examples/anchor-button/state.tsx
@@ -27,23 +27,17 @@ export function AnchorButtonState({
 	return (
 		<aside>
 			<form>
-				<InputMenu<Appearance>
-					defaultValue="Text"
+				<InputMenu
+					defaultValue="text"
 					flex
 					id="anchor-button-appearance"
 					label="Appearance"
-					onChange={(value) => {
-						const appearance = value as Appearance;
+					onChange={(event) => {
+						const appearance = event.currentTarget.value as Appearance;
 
 						setState((state) => ({ ...state, appearance }));
 					}}
-					options={[
-						{ label: "Elevated", value: "elevated" },
-						{ label: "Filled", value: "filled" },
-						{ label: "Tonal", value: "tonal" },
-						{ label: "Outlined", value: "outlined" },
-						{ label: "Text", value: "text" },
-					]}
+					options={["elevated", "filled", "tonal", "outlined", "text"]}
 				></InputMenu>
 				<Checkbox
 					label="Leading icon"

--- a/src/docs/pages/examples/button-menu/index.tsx
+++ b/src/docs/pages/examples/button-menu/index.tsx
@@ -24,7 +24,6 @@ export function ButtonMenuExample() {
 						id="button-menu-example"
 						label="Label"
 						leadingIcon={leadingIcon ? <MdMenu /> : undefined}
-						onChange={(value) => console.info("ButtonMenu", { value })}
 						options={options}
 					/>
 				</section>

--- a/src/docs/pages/examples/button-menu/state.tsx
+++ b/src/docs/pages/examples/button-menu/state.tsx
@@ -25,22 +25,19 @@ export function InputMenuState({
 	return (
 		<aside>
 			<form>
-				<InputMenu<Appearance>
-					defaultValue="Filled"
+				<InputMenu
+					defaultValue="filled"
 					flex
 					id="button-menu-appearance"
 					label="Appearance"
 					name="appearance"
-					onChange={(appearance) =>
-						setState((state) => ({ ...state, appearance }))
+					onChange={(event) =>
+						setState((state) => ({
+							...state,
+							appearance: event.currentTarget.value as Appearance,
+						}))
 					}
-					options={[
-						{ label: "Elevated", value: "elevated" },
-						{ label: "Filled", value: "filled" },
-						{ label: "Tonal", value: "tonal" },
-						{ label: "Outlined", value: "outlined" },
-						{ label: "Text", value: "text" },
-					]}
+					options={["elevated", "filled", "tonal", "outlined", "text"]}
 				/>
 				<Checkbox
 					label="Leading icon"
@@ -66,15 +63,15 @@ export function InputMenuState({
 }
 
 export const options = [
-	{ label: "Item One", value: "item-one" },
-	{ label: "Item Two", value: "item-two" },
-	{ label: "Item Three", value: "item-three" },
+	"Item One",
+	"Item Two",
+	"Item Three",
 	{ separator: true },
-	{ label: "Item Four", value: "item-four" },
-	{ label: "Item Five", value: "item-five" },
-	{ disabled: true, label: "Item Six", value: "item-six" },
-	{ label: "Item Seven", value: "item-seven" },
-	{ label: "Item Eight", value: "item-eight" },
-	{ label: "Item Nine", value: "item-nine" },
+	"Item Four",
+	"Item Five",
+	{ disabled: true, value: "Item Six" },
+	"Item Seven",
+	"Item Eight",
+	"Item Nine",
 	"Item Ten",
 ];

--- a/src/docs/pages/examples/button/state.tsx
+++ b/src/docs/pages/examples/button/state.tsx
@@ -27,23 +27,17 @@ export function ButtonState({
 	return (
 		<aside>
 			<form>
-				<InputMenu<Appearance>
-					defaultValue="Filled"
+				<InputMenu
+					defaultValue="filled"
 					flex
 					id="button-appearance"
 					label="Appearance"
-					onChange={(value) => {
-						const appearance = value as Appearance;
+					onChange={(event) => {
+						const appearance = event.currentTarget.value as Appearance;
 
 						setState((state) => ({ ...state, appearance }));
 					}}
-					options={[
-						{ label: "Elevated", value: "elevated" },
-						{ label: "Filled", value: "filled" },
-						{ label: "Tonal", value: "tonal" },
-						{ label: "Outlined", value: "outlined" },
-						{ label: "Text", value: "text" },
-					]}
+					options={["elevated", "filled", "tonal", "outlined", "text"]}
 				></InputMenu>
 				<Checkbox
 					id="button-leading-icon-checkbox"

--- a/src/docs/pages/examples/input-menu/index.tsx
+++ b/src/docs/pages/examples/input-menu/index.tsx
@@ -22,7 +22,6 @@ export function InputMenuExample() {
 						id="input-menu-example"
 						label="Label"
 						leadingIcon={leadingIcon && <MdFavorite />}
-						onChange={(value) => console.info("InputMenu", { value })}
 						options={options}
 					/>
 				</section>

--- a/src/docs/pages/examples/input-menu/state.tsx
+++ b/src/docs/pages/examples/input-menu/state.tsx
@@ -1,5 +1,6 @@
 import { Checkbox, InputMenu } from "ninjakit";
 import { Dispatch, SetStateAction, useState } from "react";
+import { MdFavorite } from "react-icons/md";
 
 type Appearance = "filled" | "outlined";
 
@@ -31,19 +32,19 @@ export function InputMenuState({
 	return (
 		<aside>
 			<form>
-				<InputMenu<"filled" | "outlined">
-					defaultValue="Filled"
+				<InputMenu
+					defaultValue="filled"
 					flex
 					id="input-menu-appearance"
 					label="Appearance"
 					name="appearance"
-					onChange={(appearance) =>
-						setState((state) => ({ ...state, appearance }))
+					onChange={(event) =>
+						setState((state) => ({
+							...state,
+							appearance: event.currentTarget.value as Appearance,
+						}))
 					}
-					options={[
-						{ label: "Filled", value: "filled" },
-						{ label: "Outlined", value: "outlined" },
-					]}
+					options={["filled", "outlined"]}
 				/>
 				<Checkbox
 					defaultChecked={flex}
@@ -88,15 +89,15 @@ export function InputMenuState({
 }
 
 export const options = [
-	{ label: "Item One", value: "item-one" },
-	{ label: "Item Two", value: "item-two" },
-	{ label: "Item Three", value: "item-three" },
+	"Item One",
+	"Item Two",
+	"Item Three",
 	{ separator: true },
-	{ label: "Item Four", value: "item-four" },
-	{ label: "Item Five", value: "item-five" },
-	{ disabled: true, label: "Item Six", value: "item-six" },
-	{ label: "Item Seven", value: "item-seven" },
-	{ label: "Item Eight", value: "item-eight" },
-	{ label: "Item Nine", value: "item-nine" },
+	"Item Four",
+	"Item Five",
+	{ disabled: true, value: "Item Six" },
+	"Item Seven",
+	{ leadingIcon: <MdFavorite />, value: "Item Eight" },
+	"Item Nine",
 	"Item Ten",
 ];

--- a/src/docs/pages/examples/password-input/state.tsx
+++ b/src/docs/pages/examples/password-input/state.tsx
@@ -1,8 +1,10 @@
 import { Checkbox, InputMenu } from "ninjakit";
 import { Dispatch, SetStateAction, useState } from "react";
 
+type Appearance = "filled" | "outlined";
+
 type PasswordInputProps = {
-	appearance: "filled" | "outlined";
+	appearance: Appearance;
 	disabled: boolean;
 	error: boolean;
 	flex: boolean;
@@ -43,19 +45,19 @@ export function PasswordInputState({
 	return (
 		<aside>
 			<form>
-				<InputMenu<"filled" | "outlined">
-					defaultValue="Filled"
+				<InputMenu
+					defaultValue="filled"
 					flex
 					id="password-input-appearance"
 					label="Appearance"
 					name="appearance"
-					onChange={(appearance) =>
-						setState((state) => ({ ...state, appearance }))
+					onChange={(event) =>
+						setState((state) => ({
+							...state,
+							appearance: event.currentTarget.value as Appearance,
+						}))
 					}
-					options={[
-						{ label: "Filled", value: "filled" },
-						{ label: "Outlined", value: "outlined" },
-					]}
+					options={["filled", "outlined"]}
 				/>
 				<Checkbox
 					defaultChecked={flex}

--- a/src/docs/pages/examples/text-input/state.tsx
+++ b/src/docs/pages/examples/text-input/state.tsx
@@ -1,8 +1,10 @@
 import { Checkbox, InputMenu } from "ninjakit";
 import { Dispatch, SetStateAction, useState } from "react";
 
+type Appearance = "filled" | "outlined";
+
 type TextInputProps = {
-	appearance: "filled" | "outlined";
+	appearance: Appearance;
 	disabled: boolean;
 	error: boolean;
 	flex: boolean;
@@ -49,19 +51,19 @@ export function TextInputState({
 	return (
 		<aside>
 			<form>
-				<InputMenu<"filled" | "outlined">
-					defaultValue="Filled"
+				<InputMenu
+					defaultValue="filled"
 					flex
 					id="text-input-appearance"
 					label="Appearance"
 					name="appearance"
-					onChange={(appearance) =>
-						setState((state) => ({ ...state, appearance }))
+					onChange={(event) =>
+						setState((state) => ({
+							...state,
+							appearance: event.currentTarget.value as Appearance,
+						}))
 					}
-					options={[
-						{ label: "Filled", value: "filled" },
-						{ label: "Outlined", value: "outlined" },
-					]}
+					options={["filled", "outlined"]}
 				/>
 				<Checkbox
 					defaultChecked={flex}

--- a/src/lib/components/checkbox/checkbox.tsx
+++ b/src/lib/components/checkbox/checkbox.tsx
@@ -32,7 +32,6 @@ export const Checkbox = forwardRef<
 							ref.current = node;
 
 							if (typeof externalRef === "function") return externalRef(node);
-							externalRef?.current === node;
 						}}
 						type="checkbox"
 					/>

--- a/src/lib/components/menu/button.tsx
+++ b/src/lib/components/menu/button.tsx
@@ -1,4 +1,5 @@
 import { Button, MenuOptions } from "ninjakit";
+import { useRef } from "react";
 import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md";
 
 import type { ButtonProps } from "../button";
@@ -6,19 +7,17 @@ import { useMenu } from ".";
 import { Menu } from "./menu";
 import styles from "./menu.module.css";
 
-export function ButtonMenu<T extends string>({
+export function ButtonMenu({
 	className: classNameOverride,
 	container,
 	id,
-	onChange,
 	options,
 	...props
 }: Omit<JSX.IntrinsicElements["button"], "id" | "onChange" | "value"> &
 	ButtonProps & {
 		container?: HTMLElement;
 		id: string;
-		onChange: (value: T) => void;
-		options: MenuOptions<T>;
+		options: MenuOptions;
 	}) {
 	const {
 		className,
@@ -26,16 +25,17 @@ export function ButtonMenu<T extends string>({
 		handleClickControl,
 		handleKeyDownControl,
 		menuId,
-		refControl,
+		refFieldset,
 		refMenu,
 		style,
 		setExpanded,
 	} = useMenu({ classNameOverride, id });
 
+	const refControl = useRef<HTMLButtonElement | null>(null);
+
 	return (
-		<fieldset className={className}>
+		<fieldset className={className} ref={refFieldset}>
 			<Button
-				{...props}
 				aria-controls={menuId}
 				aria-expanded={expanded}
 				aria-haspopup="menu"
@@ -43,15 +43,15 @@ export function ButtonMenu<T extends string>({
 				id={id}
 				onClick={handleClickControl}
 				onKeyDown={handleKeyDownControl}
-				ref={refControl}
 				trailingIcon={expanded ? <MdArrowDropUp /> : <MdArrowDropDown />}
+				{...props}
+				ref={refControl}
 			/>
 			{expanded && (
-				<Menu<T>
+				<Menu
 					container={container}
-					controlId={id}
+					controlElement={refControl.current}
 					menuId={menuId}
-					onChange={onChange}
 					options={options}
 					ref={refMenu}
 					setExpanded={setExpanded}

--- a/src/lib/components/menu/index.ts
+++ b/src/lib/components/menu/index.ts
@@ -14,7 +14,7 @@ export type MenuOptions<T extends string = string> = (
 	| T
 	| {
 			disabled?: boolean;
-			label?: ReactNode;
+			leadingIcon?: ReactNode;
 			separator?: boolean;
 			value?: T;
 	  }
@@ -109,7 +109,7 @@ export function useMenu({
 			top: y ?? "",
 		},
 		menuId,
-		refControl: reference,
+		refFieldset: reference,
 		refMenu: floating,
 		setExpanded,
 	};

--- a/src/lib/components/menu/input.tsx
+++ b/src/lib/components/menu/input.tsx
@@ -1,4 +1,5 @@
 import { MenuOptions, TextInput } from "ninjakit";
+import { forwardRef, useRef } from "react";
 import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md";
 
 import type { InputProps } from "../input";
@@ -6,37 +7,42 @@ import { useMenu } from ".";
 import { Menu } from "./menu";
 import styles from "./menu.module.css";
 
-export function InputMenu<T extends string>({
-	className: classNameOverride,
-	container,
-	flex,
-	id,
-	onChange,
-	options,
-	readOnly = true,
-	...props
-}: Omit<JSX.IntrinsicElements["input"], "onChange"> &
-	InputProps & {
-		container?: HTMLElement;
-		onChange: (value: T) => void;
-		options: MenuOptions<T>;
-	}) {
+export const InputMenu = forwardRef<
+	HTMLInputElement,
+	JSX.IntrinsicElements["input"] &
+		InputProps & {
+			container?: HTMLElement;
+			options: MenuOptions;
+		}
+>(function InputMenu(
+	{
+		className: classNameOverride,
+		container,
+		flex,
+		id,
+		options,
+		readOnly = true,
+		...props
+	},
+	ref
+) {
 	const {
 		className,
 		expanded,
 		handleClickControl,
 		handleKeyDownControl,
 		menuId,
-		refControl,
+		refFieldset,
 		refMenu,
 		setExpanded,
 		style,
 	} = useMenu({ classNameOverride, flex, id, input: true });
 
+	const refControl = useRef<HTMLInputElement | null>(null);
+
 	return (
-		<fieldset className={className}>
+		<fieldset className={className} ref={refFieldset}>
 			<TextInput
-				{...props}
 				aria-controls={menuId}
 				aria-expanded={expanded}
 				aria-haspopup="menu"
@@ -47,15 +53,18 @@ export function InputMenu<T extends string>({
 				onClickTrailingIcon={handleClickControl}
 				onKeyDown={handleKeyDownControl}
 				readOnly={readOnly}
-				ref={refControl}
 				trailingIcon={expanded ? <MdArrowDropUp /> : <MdArrowDropDown />}
+				{...props}
+				ref={(node) => {
+					if (typeof ref === "function") ref(node);
+					refControl.current = node;
+				}}
 			/>
 			{expanded && (
-				<Menu<T>
+				<Menu
 					container={container}
-					controlId={id}
+					controlElement={refControl.current}
 					menuId={menuId}
-					onChange={onChange}
 					options={options}
 					ref={refMenu}
 					setExpanded={setExpanded}
@@ -64,4 +73,4 @@ export function InputMenu<T extends string>({
 			)}
 		</fieldset>
 	);
-}
+});

--- a/src/lib/util/index.ts
+++ b/src/lib/util/index.ts
@@ -43,3 +43,18 @@ export function firstHTMLElementChild(
 ): HTMLElement | null {
 	return (element?.firstElementChild as HTMLElement) || null;
 }
+
+export function setNativeValue(element: Element, value: string) {
+	const valueSetter = Object.getOwnPropertyDescriptor(element, "value")?.set;
+	const prototype = Object.getPrototypeOf(element);
+	const prototypeValueSetter = Object.getOwnPropertyDescriptor(
+		prototype,
+		"value"
+	)?.set;
+
+	if (valueSetter && valueSetter !== prototypeValueSetter) {
+		prototypeValueSetter?.call(element, value);
+	} else {
+		valueSetter?.call(element, value);
+	}
+}


### PR DESCRIPTION
- restore native change event to menu components
- remove generic typing from menu components
- use ref to change input value from menu
- remove outdated ref usage from checkbox
- remove `label` from menu `options` prop
- add `leadingIcon` to menu `options` prop
- update usage in docs examples