### PR TITLE
fix: alert SSR

### DIFF
--- a/src/lib/components/alert/alert.tsx
+++ b/src/lib/components/alert/alert.tsx
@@ -11,7 +11,7 @@ export function Alert({
 	children,
 	className,
 	closeAfter,
-	container = document.body,
+	container,
 	...props
 }: {
 	closeAfter?: number;
@@ -59,7 +59,7 @@ export function Alert({
 								<ProgressBar progress={progress} />
 							)}
 						</div>,
-						container
+						container ? container : document.body
 				  )
 				: null}
 		</AlertContext.Provider>


### PR DESCRIPTION
- move default container prop of `Alert` provider within `mount` test to render only client-side