### PR TITLE
fix: menu options z-index (#402)

### DIFF
--- a/src/lib/components/menu/button.tsx
+++ b/src/lib/components/menu/button.tsx
@@ -4,7 +4,6 @@ import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md";
 import type { ButtonProps } from "../button";
 import { useMenu } from ".";
 import { Menu } from "./menu";
-import styles from "./menu.module.css";
 
 export function ButtonMenu({
 	className: classNameOverride,
@@ -38,7 +37,6 @@ export function ButtonMenu({
 				aria-controls={menuId}
 				aria-expanded={expanded}
 				aria-haspopup="menu"
-				className={styles.control}
 				id={id}
 				onClick={handleClickControl}
 				onKeyDown={handleKeyDownControl}

--- a/src/lib/components/menu/input.tsx
+++ b/src/lib/components/menu/input.tsx
@@ -5,7 +5,6 @@ import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md";
 import type { InputProps } from "../input";
 import { useMenu } from ".";
 import { Menu } from "./menu";
-import styles from "./menu.module.css";
 
 export const InputMenu = forwardRef<
 	HTMLInputElement,
@@ -50,7 +49,6 @@ export const InputMenu = forwardRef<
 				aria-controls={menuId}
 				aria-expanded={expanded}
 				aria-haspopup="menu"
-				className={styles.control}
 				flex={flex}
 				id={id}
 				onClick={handleClickControl}

--- a/src/lib/components/menu/menu.module.css
+++ b/src/lib/components/menu/menu.module.css
@@ -24,6 +24,7 @@
 	display: flex;
 	flex-direction: column;
 	margin-top: 0.2rem;
+	z-index: 3;
 }
 
 .menu.input {
@@ -103,8 +104,4 @@
 
 .separator {
 	border-top: 0.1rem solid var(--md-color-outline);
-}
-
-.control[aria-expanded="true"] {
-	z-index: 3;
 }


### PR DESCRIPTION
This may not be ideal, but it's a start.

We may want to consider a wider range of `z-index`es for more flexibility. In other words, higher-numbered `z-index`es with space in between, just in case. For example, `Dialog`s could be at 10, `Menu` at 20, etc, similar to how [Bootstrap does it](https://www.smashingmagazine.com/2021/02/css-z-index-large-projects/#common-solution).